### PR TITLE
comment out `requires` for high-sierra

### DIFF
--- a/macos.pc
+++ b/macos.pc
@@ -5,6 +5,6 @@ includedir=${prefix}/include
 Name: CTLS
 Description: LibreSSL / OpenSSL module map for Swift
 Version: 1.0
-Requires: libssl libcrypto
+# Requires: libssl libcrypto
 Cflags: -I${includedir}
 Libs: -L${libdir} -lssl


### PR DESCRIPTION
Fixes issues w/ the package config file working on High Sierra. 

Probably has something to do w/ the package compiling manually there. Removing now so that Vapor works w/ High Sierra. 