### PR TITLE
Add providers list to OpenSSL library

### DIFF
--- a/Package@swift-4.swift
+++ b/Package@swift-4.swift
@@ -4,6 +4,10 @@ import PackageDescription
 let package = Package(
     name: "CTLS",
     pkgConfig: "ctls",
+    providers: [
+        .brew(["openssl"]),
+        .apt(["libssl-dev"])
+    ],
     products: [
         .library(name: "CTLS", targets: ["CTLS"])
     ],


### PR DESCRIPTION
This helps [users know they need to install a dependency](https://github.com/apple/swift-package-manager/blob/master/Documentation/PackageDescriptionV4.md#providers).